### PR TITLE
Add custom CTA button feature to resume profiles

### DIFF
--- a/components/resume/FullResume.tsx
+++ b/components/resume/FullResume.tsx
@@ -10,10 +10,14 @@ export const FullResume = ({
   resume,
   profilePicture,
   allSkills,
+  isEditMode = false,
+  onCtaChange,
 }: {
   resume?: ResumeData | null;
   profilePicture?: string;
   allSkills: string[];
+  isEditMode?: boolean;
+  onCtaChange?: (cta: { label: string; url: string } | undefined) => void;
 }) => {
   if (!resume) {
     return <LoadingFallback message="Loading Resume..." />;
@@ -24,7 +28,12 @@ export const FullResume = ({
       className="mx-auto w-full max-w-2xl space-y-8 bg-white print:space-y-4 my-8 px-4"
       aria-label="Resume Content"
     >
-      <Header header={resume?.header} picture={profilePicture} />
+      <Header
+        header={resume?.header}
+        picture={profilePicture}
+        isEditMode={isEditMode}
+        onCtaChange={onCtaChange}
+      />
 
       <div className="flex flex-col gap-6">
         <Summary summary={resume?.summary} />

--- a/components/resume/Header.tsx
+++ b/components/resume/Header.tsx
@@ -5,6 +5,9 @@ import {
   Github,
   Twitter,
   Linkedin,
+  ExternalLink,
+  Pencil,
+  Plus,
 } from 'lucide-react';
 import { Button } from '@/components/ui/button';
 import { Avatar, AvatarFallback, AvatarImage } from '@/components/ui/avatar';
@@ -42,9 +45,13 @@ function SocialButton({ href, icon: Icon, label }: SocialButtonProps) {
 export function Header({
   header,
   picture,
+  isEditMode = false,
+  onCtaChange,
 }: {
   header: ResumeDataSchemaType['header'];
   picture?: string;
+  isEditMode?: boolean;
+  onCtaChange?: (cta: { label: string; url: string } | undefined) => void;
 }) {
   const prefixUrl = (stringToFix?: string) => {
     if (!stringToFix) return undefined;
@@ -83,7 +90,7 @@ export function Header({
           <a
             className="inline-flex gap-x-1.5 align-baseline leading-none hover:underline text-[#9CA0A8]"
             href={`https://www.google.com/maps/search/${encodeURIComponent(
-              header.location,
+              header.location
             )}`}
             target="_blank"
             rel="noopener noreferrer"
@@ -132,6 +139,79 @@ export function Header({
               label="LinkedIn"
             />
           )}
+          {!isEditMode && header.cta?.label && header.cta?.url && (
+            <SocialButton
+              href={prefixUrl(header.cta.url) || ''}
+              icon={ExternalLink}
+              label={header.cta.label}
+            />
+          )}
+          {isEditMode && onCtaChange && (
+            <Button
+              className="size-8"
+              variant="outline"
+              size="icon"
+              title={
+                header.cta?.label
+                  ? 'Edit call-to-action button'
+                  : 'Add call-to-action button'
+              }
+              onClick={() => {
+                // Prepare default values for the modal inputs
+                const label = header.cta?.label || '';
+                const url = header.cta?.url || '';
+
+                // Use browser dialog to edit CTA for simplicity
+                const newLabel = window.prompt(
+                  'Enter CTA label (max 40 characters):',
+                  label
+                );
+                if (newLabel === null) return; // User canceled
+
+                const newUrl = window.prompt('Enter CTA URL:', url);
+                if (newUrl === null) return; // User canceled
+
+                // Validate
+                if (newLabel.length > 40) {
+                  alert('Label must be 40 characters or less');
+                  return;
+                }
+
+                // Validate URL format
+                try {
+                  if (newLabel && newUrl) {
+                    new URL(
+                      newUrl.startsWith('http') ? newUrl : `https://${newUrl}`
+                    );
+                    onCtaChange({
+                      label: newLabel,
+                      url: newUrl,
+                    });
+                  } else if (!newLabel && !newUrl) {
+                    // Both empty means remove the CTA
+                    onCtaChange(undefined);
+                  } else {
+                    alert(
+                      'Both label and URL must be provided or both must be empty'
+                    );
+                  }
+                } catch (e) {
+                  alert('Please enter a valid URL');
+                }
+              }}
+            >
+              {header.cta?.label ? (
+                <Pencil className="size-4" aria-hidden="true" />
+              ) : (
+                <Plus className="size-4" aria-hidden="true" />
+              )}
+            </Button>
+          )}
+          {isEditMode && !header.cta?.label && (
+            <div className="text-xs text-gray-400 italic flex items-center ml-1">
+              ← Add a custom button
+            </div>
+          )}
         </div>
 
         <div
@@ -164,6 +244,17 @@ export function Header({
             >
               {header.contacts.phone}
             </a>
+          )}
+          {!isEditMode && header.cta?.label && header.cta?.url && (
+            <>
+              <span aria-hidden="true">/</span>
+              <a
+                className="underline hover:text-foreground/70"
+                href={prefixUrl(header.cta.url) || ''}
+              >
+                {header.cta.label}
+              </a>
+            </>
           )}
         </div>
       </div>

--- a/lib/resume.ts
+++ b/lib/resume.ts
@@ -14,6 +14,12 @@ const HeaderSection = z.object({
     linkedin: z.string().describe('LinkedIn username').optional(),
     github: z.string().describe('GitHub username').optional(),
   }),
+  cta: z
+    .object({
+      label: z.string().max(40).describe('Call to action label').optional(),
+      url: z.string().url().describe('Call to action URL').optional(),
+    })
+    .optional(),
   skills: z
     .array(z.string())
     .max(15)

--- a/lib/server/ai/generateResumeObject.ts
+++ b/lib/server/ai/generateResumeObject.ts
@@ -20,6 +20,7 @@ export const generateResumeObject = async (resumeText: string) => {
     - If the resume text does not include an 'about' section or specfic skills mentioned, please generate appropriate content for these sections based on the context of the resume and based on the job role.
     - For the about section: Create a professional summary that highlights the candidate's experience, expertise, and career objectives.
     - For the skills: Generate a maximum of 10 skills taken from the ones mentioned in the resume text or based on the job role / job title infer some if not present.
+    - Do not generate a CTA (call-to-action) - this is an optional field that the user can add manually later.
 
     ## Resume text:
 


### PR DESCRIPTION
# Add Custom CTA Button Feature to Self.so Resumes

## Feature Overview
This PR adds the ability for users to include a custom Call-to-Action button on their resume profiles. Users can specify both the button label (limited to 40 characters) and a target URL, allowing them to direct visitors to any external resource they want to highlight. The styling of the hyperlink is consistent with other hyperlinks on the resume.

## Implementation Details
- Added a new optional `cta` object to the resume schema with `label` and `url` fields
- Added UI for adding/editing the CTA in the preview page
- Implemented validation for label length (max 40 chars) and URL format
- Added clear visual indicators and helpful placeholder text for better UX
- Updated the AI prompt to exclude CTA generation (keeping it user-defined only)
- Made the CTA visually consistent with existing social links

## How to Use
1. Go to the resume preview page
2. Click "Add Call-to-Action Button"
3. Enter a label (max 40 chars) and URL
4. Click "Done Editing" to save and display the CTA

## Testing
- Tested with various label lengths to ensure validation works
- Verified URL validation for proper formatting
- Confirmed proper display in both desktop and print layouts
- Verified the CTA is properly hidden when not set

---

Hey Hassan! I heard we have a common friend who speaks very highly of you. I'd love to connect sometime when you're free. Again, congrats on the self.so launch! 🚀