### PR TITLE
feat: add mechanism to delete the previousy uploaded resume

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,4 +43,3 @@
 - [ ] ability to edit links in the site
 - [ ] ability to edit any section in the site
 - [ ] add themes that you can toggle on (start with ghibli)
-- [ ] Delete previously uploaded resume when we upload a new one

--- a/app/api/delete-s3/route.ts
+++ b/app/api/delete-s3/route.ts
@@ -1,0 +1,25 @@
+import { deleteS3File } from '@/lib/server/deleteS3File';
+import { NextResponse } from 'next/server';
+
+export async function POST(request: Request) {
+  try {
+    const body = await request.json();
+    const { bucket, key } = body;
+
+    if (!bucket || !key) {
+      return NextResponse.json(
+        { error: 'Missing required parameters' },
+        { status: 400 }
+      );
+    }
+
+    await deleteS3File({ bucket, key });
+    return NextResponse.json({ success: true });
+  } catch (error) {
+    console.error('Error deleting S3 file:', error);
+    return NextResponse.json(
+      { error: 'Failed to delete file' },
+      { status: 500 }
+    );
+  }
+} 

--- a/hooks/useUserActions.tsx
+++ b/hooks/useUserActions.tsx
@@ -96,6 +96,28 @@ export function useUserActions() {
 
   // Update resume data in Upstash
   const uploadFileResume = async (file: File) => {
+    // Get current resume data
+    const currentResume = await fetchResume();
+    
+    // If there's an existing file, delete it from S3
+    if (currentResume.resume?.file?.bucket && currentResume.resume?.file?.key) {
+      try {
+        await fetch('/api/delete-s3', {
+          method: 'POST',
+          headers: {
+            'Content-Type': 'application/json',
+          },
+          body: JSON.stringify({
+            bucket: currentResume.resume.file.bucket,
+            key: currentResume.resume.file.key,
+          }),
+        });
+      } catch (error) {
+        console.error('Error deleting previous file:', error);
+        // Continue with upload even if deletion fails
+      }
+    }
+
     const fileOnS3 = await uploadToS3(file);
 
     const newResume: Resume = {

--- a/lib/server/deleteS3File.ts
+++ b/lib/server/deleteS3File.ts
@@ -1,11 +1,10 @@
 import AWS from 'aws-sdk';
 
+// Configure AWS with credentials from environment variables
 AWS.config.update({
-  region: process.env.S3_UPLOAD_REGION!!,
-  credentials: {
-    accessKeyId: process.env.AWS_ACCESS_KEY_ID!!,
-    secretAccessKey: process.env.AWS_SECRET_ACCESS_KEY!!,
-  },
+  region: process.env.S3_UPLOAD_REGION,
+  accessKeyId: process.env.S3_UPLOAD_KEY,
+  secretAccessKey: process.env.S3_UPLOAD_SECRET,
 });
 
 export const deleteS3File = async ({
@@ -16,15 +15,17 @@ export const deleteS3File = async ({
   key: string;
 }) => {
   const s3 = new AWS.S3();
-  const bucketName = process.env.S3_BUCKET_NAME;
 
   const params = { Bucket: bucket, Key: key };
 
   console.log(`Deleting file ${key} from S3.`);
 
-  await s3.deleteObject(params).promise();
-
-  console.log(`File ${key} deleted from S3.`);
-
-  return { success: true };
+  try {
+    await s3.deleteObject(params).promise();
+    console.log(`File ${key} deleted from S3.`);
+    return { success: true };
+  } catch (error) {
+    console.error('Error in deleteS3File:', error);
+    throw error;
+  }
 };


### PR DESCRIPTION
# Delete Previous Resume on New Upload

This PR implements the functionality to automatically delete the previously uploaded resume from S3 when a user uploads a new one. This helps maintain storage efficiency and ensures we don't accumulate unused files in our S3 bucket.

## Changes Made
1. Modified `hooks/useUserActions.tsx`:
   - Added logic to fetch current resume data before new upload
   - Added functionality to delete existing S3 file if present
   - Implemented error handling that allows upload to continue even if deletion fails

2. Added new API endpoint `app/api/delete-s3/route.ts`:
   - Created endpoint to handle S3 file deletion requests
   - Implemented proper error handling and response status codes
   - Added parameter validation

3. Fixed AWS credentials in `lib/server/deleteS3File.ts`:
   - Updated AWS configuration to use correct environment variable names
   - Added better error handling and logging
   - Fixed credentials configuration to match `.example.env` structure
   
4. Remove delete previous resume from future tasks list. 

## Testing
To test this change:
1. Upload an initial resume PDF
2. Verify the file is stored in S3
3. Upload a different resume PDF
4. Verify:
   - The new file is uploaded successfully
   - The old file is deleted from S3
   - The user's profile shows the new resume

## Additional Notes
- The implementation gracefully handles cases where no previous file exists
- If deletion fails, the error is logged but doesn't block the new upload