### PR TITLE
Feat: Add Ability to Access Preview Page for Existing Site

### DIFF
--- a/app/(private)/preview/page.tsx
+++ b/app/(private)/preview/page.tsx
@@ -18,12 +18,12 @@ async function LLMProcessing({ userId }: { userId: string }) {
 
   let resume = await getResume(userId);
 
-  if (!resume?.fileContent || !resume.file) redirect('/upload');
+  if (!resume) redirect('/upload');
 
   let messageTip: string | undefined;
 
-  if (!resume.resumeData) {
-    let resumeObject = await generateResumeObject(resume?.fileContent);
+  if (!resume.resumeData && resume.fileContent) {
+    let resumeObject = await generateResumeObject(resume.fileContent);
 
     if (!resumeObject) {
       messageTip =
@@ -60,7 +60,7 @@ async function LLMProcessing({ userId }: { userId: string }) {
       .toString(36)
       .substring(2, 2 + saltLength);
 
-  if (!foundUsername) {
+  if (!foundUsername && resume.resumeData) {
     const username =
       (
         (resume.resumeData.header.name || 'user')

--- a/app/(private)/upload/client.tsx
+++ b/app/(private)/upload/client.tsx
@@ -70,6 +70,18 @@ export default function UploadPageClient() {
           personal site
         </h1>
 
+        {resume?.resumeData && (
+          <div className="mb-6">
+            <Button
+              variant="outline"
+              className="w-full"
+              onClick={() => router.push('/preview')}
+            >
+              Go to Preview
+            </Button>
+          </div>
+        )}
+
         <div className="relative mx-2.5">
           {fileState.status !== 'empty' && (
             <button


### PR DESCRIPTION
# Add Ability to Access Preview Page for Existing Site

This PR adds the ability for users to access their preview page if they already have a site, improving the user experience by providing quick access to their existing content.
![image](https://github.com/user-attachments/assets/52aeb07c-b41c-4722-aeb7-fba8d136ceb6)

## Changes Made
1. Modified `app/(private)/upload/client.tsx`:
   - Added a "Go to Preview" button that appears when a user has existing resume data
   - Button is placed prominently above the file upload area
   - Uses the existing router to navigate to the preview page

2. Updated `app/(private)/preview/page.tsx`:
   - Modified the redirect logic to only redirect if there's no resume data at all
   - Added proper null checks for resume data and file content
   - Improved type safety with additional checks

## Testing
To test this change:
1. Create a new account and upload a resume
2. Go back to the upload page
3. Verify that the "Go to Preview" button appears
4. Click the button and verify it takes you to the preview page
5. Verify that the preview page shows your existing content

## Additional Notes
- The implementation maintains all existing functionality
- Added proper type safety and null checks
- The preview button only appears when there's actual resume data to show