### PR TITLE
feat: add white-space: pre-line to description paragraph #42

### DIFF
--- a/components/resume/WorkExperience.tsx
+++ b/components/resume/WorkExperience.tsx
@@ -67,7 +67,7 @@ export function WorkExperience({
                   {item.company && item.contract && <span>·</span>}
                   <span>{item.contract}</span>
                 </p>
-                <p className="self-stretch text-sm font-medium text-left text-[#6c737f]">
+                <p className="self-stretch text-sm font-medium text-left text-[#6c737f] whitespace-pre-line">
                   {item.description}
                 </p>
               </div>


### PR DESCRIPTION
## Feature Request: Improve text formatting in <p> element for work description

I suggest adding the CSS rule `white-space: pre-line` to the paragraph element that renders `item.description` in the work experience section.

### Motivation:
Currently, the `description` is rendered in a `<p>` without line breaks or bullets correctly shown. This causes multi-line content with `\n` characters to render as a long blob of text.

### Proposed solution:
Add `white-space: pre-line;` to the class that controls this paragraph, like:

```tsx
<p className="... whitespace-pre-line">
  {item.description}
</p>
