### PR TITLE
Currently, the description is rendered in a <p> without line breaks o…

### DIFF
--- a/components/resume/WorkExperience.tsx
+++ b/components/resume/WorkExperience.tsx
@@ -67,7 +67,7 @@ export function WorkExperience({
                   {item.company && item.contract && <span>·</span>}
                   <span>{item.contract}</span>
                 </p>
-                <p className="self-stretch text-sm font-medium text-left text-[#6c737f]">
+                <p className="self-stretch text-sm font-medium text-left whitespace-pre-line text-[#6c737f]">
                   {item.description}
                 </p>
               </div>


### PR DESCRIPTION
…r bullets correctly shown white-space: pre-line CLOSES #31 